### PR TITLE
Prevent app from scrolling vertically

### DIFF
--- a/public/jsx/app.jsx
+++ b/public/jsx/app.jsx
@@ -234,7 +234,7 @@ class App extends React.Component {
       elevationHeight = 0;
     }
 
-    return this.state.windowHeight - elevationHeight - titlebarHeight;
+    return this.state.windowHeight - elevationHeight - titlebarHeight - 1; //  -1 removes vertical scroll wiggle
   }
 
   isMobile(width) {
@@ -243,7 +243,7 @@ class App extends React.Component {
   }
 
   render() {
-    const controlsHeight = 212;
+    const controlsHeight = 300; // measured to prevent vertical scroll
     const sidebarWidth = 300;
     let elevationWidth;
     let directionsHeight;


### PR DESCRIPTION
In a recent change, a donate prompt was added to the left sidebar. The vertical heights of each div are precisely accounted for to prevent the Directions div from getting too tall and causing the whole app to scroll vertically. This PR updates the accounting to include the Donate div, thus preventing vertical scroll.

I also noticed similar accounting for the map and elevation chart stack. I removed 1 phantom pixel, which got rid of the vertical scroll bar. I'm not sure where that phantom pixel came from.

I've tested this change with a macbook pro retina screen on Firefox, Safari, Chrome. and on an iPhone 6+ on Safari. Due to the different layout, there is no difference on mobile. I've confirmed the problem to be fixed on the 3 desktop browsers. Firefox accounts for the height of each div slightly differently, which I think is the cause of an extra little bit of whitespace below the directions list on Chrome and Safari. I also used the "print to PDF" functionality on Chrome and Firefox after the change and it looks fine.

Chrome Before:
<img width="687" alt="screen shot 2018-08-23 at 2 17 18 pm" src="https://user-images.githubusercontent.com/2433182/44552510-6065c400-a6df-11e8-8a38-8816404c25c1.png">


Chrome After:

<img width="687" alt="screen shot 2018-08-23 at 2 17 42 pm" src="https://user-images.githubusercontent.com/2433182/44552499-580d8900-a6df-11e8-8b11-bb3a938666a9.png">

Firefox Before:
<img width="739" alt="screen shot 2018-08-23 at 2 19 50 pm" src="https://user-images.githubusercontent.com/2433182/44552604-ac186d80-a6df-11e8-8b77-15d359c9e674.png">



Firefox After:
<img width="769" alt="screen shot 2018-08-23 at 2 19 08 pm" src="https://user-images.githubusercontent.com/2433182/44552610-afabf480-a6df-11e8-9804-b7b299914a8b.png">



In a future PR, I'd like to separate the presentational and functional logic such that the layout logic can be consolidated in one place. Right now each component needs to know its own height, and it is redundantly specified in CSS. Furthermore I'd like to use Flexbox to let the browser handle the height calculations, removing these calculations from the app. Any reasons not to do this would be welcome.